### PR TITLE
feat: add the number of agents associated with a tag

### DIFF
--- a/internal/views/admin_views/tags_views.templ
+++ b/internal/views/admin_views/tags_views.templ
@@ -9,6 +9,7 @@ import (
 	"github.com/open-uem/openuem-console/internal/views/layout"
 	"github.com/open-uem/openuem-console/internal/views/partials"
 	"math/rand"
+	"strconv"
 )
 
 templ Tags(c echo.Context, p partials.PaginationAndSort, sm *sessions.SessionManager, currentVersion, latestVersion string, tags []*ent.Tag, agentsExists, serversExists bool) {
@@ -39,7 +40,7 @@ templ Tags(c echo.Context, p partials.PaginationAndSort, sm *sessions.SessionMan
 							<table class="uk-table uk-table-divider uk-table-small uk-table-hover uk-table-striped border border-gray-400!important mt-6">
 								<thead>
 									<tr>
-										<th class="w-1/4">
+										<th class="w-1/6">
 											<div class="flex gap-1 items-center">
 												<span>{ i18n.T(ctx, "Tag.one") }</span>
 												@partials.SortByColumnIcon(c, p, i18n.T(ctx, "Tag.one"), "tag", "alpha", "#main", "outerHTML")
@@ -51,9 +52,14 @@ templ Tags(c echo.Context, p partials.PaginationAndSort, sm *sessions.SessionMan
 												@partials.SortByColumnIcon(c, p, i18n.T(ctx, "tags.descr"), "description", "alpha", "#main", "outerHTML")
 											</div>
 										</th>
-										<th class="w-1/4">
+										<th class="w-1/6">
 											<div class="flex gap-1 items-center">
 												<span>{ i18n.T(ctx, "tags.color") }</span>
+											</div>
+										</th>
+										<th class="w-1/6">
+											<div class="flex gap-1 items-center">
+												<span>{ i18n.T(ctx, "tags.count") }</span>
 											</div>
 										</th>
 										<th>
@@ -72,6 +78,13 @@ templ Tags(c echo.Context, p partials.PaginationAndSort, sm *sessions.SessionMan
 												title="color"
 												class={ "rounded-full px-5 py-1 text-white inline-block", fmt.Sprintf("bg-%s-500", tag.Color) }
 											>{ i18n.T(ctx, "Example") }</div>
+										</td>
+										<td class="!aling-middle">
+											if tag.Edges.Owner != nil {
+												{ strconv.Itoa(len(tag.Edges.Owner)) }
+											} else {
+												{ "0" }
+											}
 										</td>
 										<td class="flex gap-4 items-center mt-1">
 											<button

--- a/internal/views/locales/en.yaml
+++ b/internal/views/locales/en.yaml
@@ -467,6 +467,7 @@ en:
     edit_tag: "Edit the tag according to your needs"
     add_tags: "Add tags!"
     filter_by: "Filter by tags"
+    count: "# Agents"
   metadata:
     description: "Here you can define the metadata that you want to add to your computers and which are valuable to your organization. You could add your org's inventory number to an computer. The metadata that you create here will be available in the Metadata table inside your computer's view"
     no_metadata: "No metadata for your org has been defined yet"

--- a/internal/views/locales/es.yaml
+++ b/internal/views/locales/es.yaml
@@ -465,6 +465,7 @@ es:
     edit_tag: "Edite la etiqueta de acuerdo con sus necesidades"
     add_tags: "¡Añada etiquetas!"
     filter_by: "Filtrar por etiquetas"
+    count: "Num. Agentes"
   metadata:
     description: "Aquí puede definir los metadatos que quiere añadir a sus equipos y que son valiosos para su organización. Por ejemplo puede añadir a un equipo el número de inventario de su organización. Los metadatos que cree aquí estarán disponibles en la pestaña Metadatos de la vista de su equipo"
     no_metadata: "Aún no ha definido metadatos para su organización"


### PR DESCRIPTION
A new column is added to the Admin -> Tags section so we can know how many agents have this tag assigned

![image](https://github.com/user-attachments/assets/f12cd64d-e777-4181-ba16-1fbc7f99f80e)

Closes #20 