### PR TITLE
fix: remove filterByApplication from the apps filter url when paginating

### DIFF
--- a/internal/controllers/webserver/handlers/computers.go
+++ b/internal/controllers/webserver/handlers/computers.go
@@ -407,13 +407,17 @@ func (h *Handler) ComputersList(c echo.Context, successMessage string, comesFrom
 	}
 	f.IsRemote = filteredIsRemote
 
-	if c.FormValue("filterByApplication") != "" {
-		if comesFromDialog {
-			u, err := url.Parse(c.Request().Header.Get("Hx-Current-Url"))
-			if err == nil {
-				f.WithApplication = u.Query().Get("filterByApplication")
-			}
-		} else {
+	if c.FormValue("selectedApp") != "" {
+		f.WithApplication = c.FormValue("selectedApp")
+	}
+
+	if comesFromDialog {
+		u, err := url.Parse(c.Request().Header.Get("Hx-Current-Url"))
+		if err == nil {
+			f.WithApplication = u.Query().Get("filterByApplication")
+		}
+	} else {
+		if c.FormValue("filterByApplication") != "" {
 			f.WithApplication = c.FormValue("filterByApplication")
 		}
 	}

--- a/internal/views/software_views/software_views.templ
+++ b/internal/views/software_views/software_views.templ
@@ -71,7 +71,7 @@ templ Software(c echo.Context, p partials.PaginationAndSort, f filters.Applicati
 								<td class="uk-width-1-3 !align-middle">{ app.Publisher }</td>
 								<td class="uk-width-1-6 !align-middle text-center">
 									<form>
-										<input type="hidden" id="filterByApplication" name="filterByApplication" value={ app.Name }/>
+										<input type="hidden" id="selectedApp" name="selectedApp" value={ app.Name }/>
 										<span
 											class="underline cursor-pointer"
 											hx-post="/computers"


### PR DESCRIPTION
It's not a bug but a side effect, this fix removes the filterByApplication entries from the software pagination

Closes #37 