### PR TITLE
feat: add free space tooltip in percentage and change size columns order

### DIFF
--- a/internal/views/computers_views/logical_disks.templ
+++ b/internal/views/computers_views/logical_disks.templ
@@ -46,8 +46,8 @@ templ LogicalDisks(c echo.Context, p partials.PaginationAndSort, sm *sessions.Se
 									<th>{ i18n.T(ctx, "inventory.logical_disk.volume_name") }</th>
 									<th>{ i18n.T(ctx, "inventory.logical_disk.filesystem") }</th>
 									<th>{ i18n.T(ctx, "inventory.logical_disk.usage") }</th>
-									<th>{ i18n.T(ctx, "inventory.logical_disk.total_size") }</th>
 									<th>{ i18n.T(ctx, "inventory.logical_disk.remaining_space") }</th>
+									<th>{ i18n.T(ctx, "inventory.logical_disk.total_size") }</th>
 									<th>{ i18n.T(ctx, "inventory.logical_disk.bitlocker") }</th>
 									if  agent.SftpPort != "" {
 										<th>{ i18n.T(ctx, "inventory.file_browser.title") }</th>
@@ -66,12 +66,13 @@ templ LogicalDisks(c echo.Context, p partials.PaginationAndSort, sm *sessions.Se
 									<td class="!align-middle">
 										<progress
 											class="uk-progress !mb-0"
+											uk-tooltip={ fmt.Sprintf("title: %s", i18n.T(ctx, "agents.free_space", 100-int(disk.Usage))) }
 											value={ strconv.Itoa(int(disk.Usage)) }
 											max="100"
 										></progress>
 									</td>
-									<td class="!align-middle">{ disk.SizeInUnits }</td>
 									<td class="!align-middle">{ disk.RemainingSpaceInUnits }</td>
+									<td class="!align-middle">{ disk.SizeInUnits }</td>
 									<td class="!align-middle">
 										@partials.BitlockerStatus(disk.BitlockerStatus)
 									</td>

--- a/internal/views/locales/en.yaml
+++ b/internal/views/locales/en.yaml
@@ -217,6 +217,7 @@ en:
     remote: "Is remote?"
     is_remote: "Agent is in a remote location"
     sftp_not_available: "The SFTP service is not available"
+    free_space: "Free space %d%%"
   inventory:
     hardware:
       title: "Hardware"

--- a/internal/views/locales/es.yaml
+++ b/internal/views/locales/es.yaml
@@ -217,6 +217,7 @@ es:
     remote: "¿En remoto?"
     is_remote: "El agente está en una ubicación remota"
     sftp_not_available: "El servicio SFTP no está disponible"
+    free_space: "Espacio libre %d%%"
   inventory:
     hardware:
       title: "Hardware"


### PR DESCRIPTION
A tooltip shows the free space percentage:

![image](https://github.com/user-attachments/assets/391f6629-6e39-4639-8d6c-47b377222c5b)

Remaining space column shows before total size column in logical disks' view

Closes #53