### PR TITLE
feat: add icon for agents that hasn't contacted in 24 hours

### DIFF
--- a/internal/models/computers.go
+++ b/internal/models/computers.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"context"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	ent "github.com/open-uem/ent"
@@ -26,7 +27,8 @@ type Computer struct {
 	Manufacturer string
 	Model        string
 	Serial       string
-	Is_Remote    bool
+	IsRemote     bool      `sql:"is_remote"`
+	LastContact  time.Time `sql:"last_contact"`
 	Tags         []*ent.Tag
 }
 
@@ -46,7 +48,7 @@ func (m *Model) CountAllComputers(f filters.AgentFilter) (int, error) {
 }
 
 func mainQuery(s *sql.Selector, p partials.PaginationAndSort) {
-	s.Select(sql.As(agent.FieldID, "ID"), agent.FieldHostname, agent.FieldOs, "`t2`.`version`", agent.FieldIP, agent.FieldMAC, operatingsystem.FieldUsername, computer.FieldManufacturer, computer.FieldModel, computer.FieldSerial, agent.FieldIsRemote).
+	s.Select(sql.As(agent.FieldID, "ID"), agent.FieldHostname, agent.FieldOs, "`t2`.`version`", agent.FieldIP, agent.FieldMAC, operatingsystem.FieldUsername, computer.FieldManufacturer, computer.FieldModel, computer.FieldSerial, agent.FieldIsRemote, agent.FieldLastContact).
 		LeftJoin(sql.Table(computer.Table)).
 		On(agent.FieldID, computer.OwnerColumn).
 		LeftJoin(sql.Table(operatingsystem.Table)).

--- a/internal/views/agents_views/agents.templ
+++ b/internal/views/agents_views/agents.templ
@@ -11,6 +11,7 @@ import (
 	"github.com/open-uem/openuem-console/internal/views/layout"
 	"github.com/open-uem/openuem-console/internal/views/partials"
 	"strconv"
+	"time"
 )
 
 var AgentStatus = []string{"WaitingForAdmission", "Enabled", "Disabled"}
@@ -412,14 +413,14 @@ templ AgentsTableBody(p partials.PaginationAndSort, l locales.Translator, agents
 				}
 			</td>
 			<td
-				class="!align-middle underline hover:cursor-pointer"
+				class="!align-middle hover:cursor-pointer"
 				hx-get={ string(templ.URL(fmt.Sprintf("/computers/%s", agent.ID))) }
 				hx-push-url="true"
 				hx-target="#main"
 				hx-swap="outerHTML"
 			>
 				<div class="flex items-center gap-2">
-					{ agent.Hostname }
+					<span class="underline">{ agent.Hostname }</span>
 					if agent.RestartRequired {
 						@partials.AlertIcon(i18n.T(ctx, "agents.restart_required"))
 					}
@@ -428,6 +429,12 @@ templ AgentsTableBody(p partials.PaginationAndSort, l locales.Translator, agents
 							<uk-icon hx-history="false" icon="search-check" custom-class="h-5 w-5 text-red-600" uk-cloack></uk-icon>
 						</div>
 					}
+					if (time.Now().Sub(agent.LastContact).Hours()) > 24 {
+						<div uk-tooltip={ i18n.T(ctx, "agents.no_contact_in_last_day") }>
+							<uk-icon hx-history="false" icon="clock-8" custom-class="h-5 w-5 text-red-600" uk-cloack></uk-icon>
+						</div>
+					}
+					// time.Now().AddDate(0, 0, -1)
 				</div>
 			</td>
 			<td class="!align-middle">

--- a/internal/views/computers_views/computers_views.templ
+++ b/internal/views/computers_views/computers_views.templ
@@ -12,6 +12,7 @@ import (
 	"github.com/open-uem/openuem-console/internal/views/layout"
 	"github.com/open-uem/openuem-console/internal/views/partials"
 	"strings"
+	"time"
 )
 
 templ Computers(c echo.Context, p partials.PaginationAndSort, f filters.AgentFilter, sm *sessions.SessionManager, l locales.Translator, currentVersion, latestVersion string, agents []models.Computer, versions, vendors, models []string, availableTags []*openuem_ent.Tag, availableOSes []string, refreshTime int, successMessage string) {
@@ -143,14 +144,23 @@ templ ComputersBody(p partials.PaginationAndSort, agents []models.Computer, avai
 	for index, agent := range agents {
 		<tr class="h-16">
 			<td
-				class="!align-middle underline cursor-pointer"
+				class="!align-middle cursor-pointer"
 				hx-get={ string(templ.URL(fmt.Sprintf("/computers/%s", agent.ID))) }
 				hx-push-url="true"
 				hx-target="#main"
 				hx-swap="outerHTML"
-			>{ agent.Hostname }</td>
+			>
+				<div class="flex items-center gap-2">
+					<span class="underline">{ agent.Hostname }</span>
+					if (time.Now().Sub(agent.LastContact).Hours()) > 24 {
+						<div uk-tooltip={ i18n.T(ctx, "agents.no_contact_in_last_day") }>
+							<uk-icon hx-history="false" icon="clock-8" custom-class="h-5 w-5 text-red-600" uk-cloack></uk-icon>
+						</div>
+					}
+				</div>
+			</td>
 			<td class="!align-middle">
-				if agent.Is_Remote {
+				if agent.IsRemote {
 					<span uk-tooltip={ fmt.Sprintf("title: %s", i18n.T(ctx, "agents.is_remote")) }>
 						<uk-icon hx-history="false" icon="plane" custom-class="h-6 w-6 text-blue-600" uk-cloack></uk-icon>
 					</span>

--- a/internal/views/locales/en.yaml
+++ b/internal/views/locales/en.yaml
@@ -233,6 +233,7 @@ en:
     could_not_generate_rdp_file: "Could not generate RDP file"
     rdp_file_warning: "Be warned, you must click on the Disconnect button to stop the remote desktop service of the endpoint. Closing the remote desktop client app is not enough to stop the remote service"
     filter_by_source: "Filter by package source"
+    no_contact_in_last_day: "Agent hasn't contacted in the last 24 hours"
   inventory:
     hardware:
       title: "Hardware"

--- a/internal/views/locales/es.yaml
+++ b/internal/views/locales/es.yaml
@@ -233,6 +233,7 @@ es:
     could_not_generate_rdp_file: "No se pudo generar el fichero RDP"
     rdp_file_warning: "Tenga esto en cuenta, debe hacer click en el botón de Desconectar para parar el servicio de escritorio remoto en el servicio. No basta con cerrar la aplicación cliente de escritorio remoto"
     filter_by_source: "Filtrar por origen del paquete"
+    no_contact_in_last_day: "El agente no ha contactado en las últimas 24 horas"
   inventory:
     hardware:
       title: "Hardware"


### PR DESCRIPTION
A new icon is shown next to the hostname in agents and computers view to identify these agents

![image](https://github.com/user-attachments/assets/e200926a-0b6f-42de-a23e-65b51cfcac1d)

Closes #62 