### PR TITLE
fix: new source2.msix replace failing source.msix CDN url

### DIFF
--- a/internal/common/check_updates.go
+++ b/internal/common/check_updates.go
@@ -25,7 +25,7 @@ func (w *Worker) StartCheckLatestReleasesJob(channel string) error {
 	if err := w.StartDownloadLatestAgentReleaseJob(channel); err != nil {
 		return err
 	}
-	log.Println("[INFO]: check latest releases job has been scheduled every ", w.DownloadLatestReleaseJobDuration.String())
+	log.Printf("[INFO]: check latest releases job has been scheduled every %d hours", 6)
 	return nil
 }
 

--- a/internal/common/flatpakdb.go
+++ b/internal/common/flatpakdb.go
@@ -15,7 +15,7 @@ func (w *Worker) StartFlatpakDBDownloadJob() error {
 	// Try to download at start
 	if err := w.DownloaFlatpakDB(); err != nil {
 		log.Printf("[ERROR]: could not get flatpak.db, reason: %v", err)
-		w.DownloadFlatpakJobDuration = 5 * time.Second
+		w.DownloadFlatpakJobDuration = 30 * time.Minute
 	} else {
 		log.Println("[INFO]: flatpak.db has been downloaded")
 		w.DownloadFlatpakJobDuration = 24 * time.Hour
@@ -26,7 +26,7 @@ func (w *Worker) StartFlatpakDBDownloadJob() error {
 		log.Printf("[ERROR]: could not start the flatpak download job: %v", err)
 		return err
 	}
-	log.Println("[INFO]: download flatpak.db job has been scheduled every ", w.DownloadFlatpakJobDuration.String())
+	log.Printf("[INFO]: download flatpak.db job has been scheduled every %d minutes", 30)
 	return nil
 }
 

--- a/internal/common/server_releases.go
+++ b/internal/common/server_releases.go
@@ -50,7 +50,7 @@ func (w *Worker) StartServerReleasesDownloadJob() error {
 	// Try to download server releases at start
 	if err := w.GetServerReleases(); err != nil {
 		log.Printf("[ERROR]: could not get server releases, reason: %v", err)
-		w.DownloadServerReleasesJobDuration = 2 * time.Minute
+		w.DownloadServerReleasesJobDuration = 10 * time.Minute
 	} else {
 		log.Println("[INFO]: server releases files have been downloaded")
 		w.DownloadServerReleasesJobDuration = 6 * time.Hour
@@ -58,7 +58,7 @@ func (w *Worker) StartServerReleasesDownloadJob() error {
 
 	// Create task
 	if err := w.StartDownloadServerReleasesJob(); err == nil {
-		log.Println("[INFO]: download server releases job has been scheduled every " + w.DownloadServerReleasesJobDuration.String())
+		log.Printf("[INFO]: download server releases job has been scheduled every %d minutes", 10)
 	}
 	return nil
 }

--- a/internal/common/software_package.go
+++ b/internal/common/software_package.go
@@ -56,7 +56,10 @@ func (w *Worker) StartCommonPackagesDBJob() error {
 	if err != nil {
 		log.Println("[INFO]: could not get winget database")
 	} else {
-		rows, err := wingetDB.Query(`SELECT DISTINCT ids.id as id, names.name AS name FROM manifest LEFT JOIN ids ON manifest.id = ids.rowid LEFT JOIN names ON manifest.name = names.rowid`)
+		// Old source.msix database information fix-68
+		// rows, err := wingetDB.Query(`SELECT DISTINCT ids.id as id, names.name AS name FROM manifest LEFT JOIN ids ON manifest.id = ids.rowid LEFT JOIN names ON manifest.name = names.rowid`)
+		rows, err := wingetDB.Query(`SELECT DISTINCT id, name FROM packages`)
+
 		if err != nil {
 			log.Println("[INFO]: could not query winget apps")
 		} else {

--- a/internal/common/wingetdb.go
+++ b/internal/common/wingetdb.go
@@ -16,7 +16,7 @@ func (w *Worker) StartWinGetDBDownloadJob() error {
 	// Try to download at start
 	if err := w.DownloadWgetDB(); err != nil {
 		log.Printf("[ERROR]: could not get index.db, reason: %v", err)
-		w.DownloadWingetJobDuration = 5 * time.Second
+		w.DownloadWingetJobDuration = 30 * time.Minute
 	} else {
 		log.Println("[INFO]: winget index.db has been downloaded")
 		w.DownloadWingetJobDuration = 24 * time.Hour
@@ -27,12 +27,12 @@ func (w *Worker) StartWinGetDBDownloadJob() error {
 		log.Printf("[ERROR]: could not start the winget download job: %v", err)
 		return err
 	}
-	log.Println("[INFO]: download winget index.db job has been scheduled every ", w.DownloadWingetJobDuration.String())
+	log.Printf("[INFO]: download winget index.db job has been scheduled every %d minutes", 30)
 	return nil
 }
 
 func (w *Worker) DownloadWgetDB() error {
-	url := "https://cdn.winget.microsoft.com/cache/source.msix"
+	url := "https://cdn.winget.microsoft.com/cache/source2.msix"
 
 	// If we're in development don't download
 	if os.Getenv("DEVEL") == "true" {
@@ -106,7 +106,7 @@ func (w *Worker) StartDownloadWingetDBJob() error {
 			func() {
 				if err := w.DownloadWgetDB(); err != nil {
 					log.Printf("[ERROR]: could not get index.db, reason: %v", err)
-					jobDuration = 2 * time.Minute
+					jobDuration = 30 * time.Minute
 				} else {
 					jobDuration = 24 * time.Hour
 				}


### PR DESCRIPTION
For three days the CDN url for source.msix is failing. We replace it with source2.msix that should have the same information, but has different tables

Closes #68 