### PR TITLE
Fix: create default tenand and site should be run after initial settings are created

### DIFF
--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -23,6 +23,36 @@ func (w *Worker) StartDBConnectJob() error {
 			log.Println("[WARN]: could not create initial settings")
 		}
 
+		// Create default orgs and sites #feat-119
+		if err := w.Model.CreateDefaultTenantAndSite(); err != nil {
+			log.Println("[WARN]: could not create initial settings")
+		}
+
+		// Associate agents without site to default site #feat-119
+		if err := w.Model.AssociateAgentsToDefaultTenantAndSite(); err != nil {
+			log.Println("[WARN]: could not associate agents to default tenant and site")
+		}
+
+		// Associate tags without tenant to default tenant #feat-119
+		if err := w.Model.AssociateTagsToDefaultTenant(); err != nil {
+			log.Println("[WARN]: could not associate tags to default tenant")
+		}
+
+		// Associate metadata without tenant to default tenant #feat-119
+		if err := w.Model.AssociateMetadataToDefaultTenant(); err != nil {
+			log.Println("[WARN]: could not associate metadata to default tenant")
+		}
+
+		// Associate profiles without tenant to default tenant #feat-119
+		if err := w.Model.AssociateProfilesToDefaultTenantAndSite(); err != nil {
+			log.Println("[WARN]: could not associate profiles to default tenant and site")
+		}
+
+		// Associate domain to default site #feat-119
+		if err := w.Model.AssociateDomainToDefaultSite(w.Domain); err != nil {
+			log.Println("[WARN]: could not associate domain to default site")
+		}
+
 		w.StartConsoleService()
 
 		// Start a job to check latest OpenUEM releases
@@ -64,6 +94,36 @@ func (w *Worker) StartDBConnectJob() error {
 
 				if err := w.Model.CreateInitialSettings(); err != nil {
 					log.Println("[WARN]: could not create initial settings")
+				}
+
+				// Create default orgs and sites #feat-119
+				if err := w.Model.CreateDefaultTenantAndSite(); err != nil {
+					log.Println("[WARN]: could not create default tenant and site")
+				}
+
+				// Associate agents without site to default site #feat-119
+				if err := w.Model.AssociateAgentsToDefaultTenantAndSite(); err != nil {
+					log.Println("[WARN]: could not associate agents to default tenant and site")
+				}
+
+				// Associate tags without tenant to default tenant #feat-119
+				if err := w.Model.AssociateTagsToDefaultTenant(); err != nil {
+					log.Println("[WARN]: could not associate tags to default tenant")
+				}
+
+				// Associate metadata without tenant to default tenant #feat-119
+				if err := w.Model.AssociateMetadataToDefaultTenant(); err != nil {
+					log.Println("[WARN]: could not associate metadata to default tenant")
+				}
+
+				// Associate profiles without tenant to default tenant #feat-119
+				if err := w.Model.AssociateProfilesToDefaultTenantAndSite(); err != nil {
+					log.Println("[WARN]: could not associate profiles to default tenant and site")
+				}
+
+				// Associate domain to default site #feat-119
+				if err := w.Model.AssociateDomainToDefaultSite(w.Domain); err != nil {
+					log.Println("[WARN]: could not associate domain to default site")
 				}
 
 				w.StartConsoleService()

--- a/internal/controllers/webserver/handlers/handler.go
+++ b/internal/controllers/webserver/handlers/handler.go
@@ -194,6 +194,7 @@ func (h *Handler) StartNATSConnectJob() error {
 				h.ServerStream, err = h.JetStream.Stream(ctx, "SERVERS_STREAM")
 				if err != nil {
 					log.Printf("[ERROR]: Server Stream could not be created or updated, reason: %v", err)
+					return
 				}
 
 				if err := h.TaskScheduler.RemoveJob(h.NATSConnectJob.ID()); err != nil {

--- a/internal/controllers/webserver/handlers/handler.go
+++ b/internal/controllers/webserver/handlers/handler.go
@@ -194,7 +194,6 @@ func (h *Handler) StartNATSConnectJob() error {
 				h.ServerStream, err = h.JetStream.Stream(ctx, "SERVERS_STREAM")
 				if err != nil {
 					log.Printf("[ERROR]: Server Stream could not be created or updated, reason: %v", err)
-					return
 				}
 
 				if err := h.TaskScheduler.RemoveJob(h.NATSConnectJob.ID()); err != nil {

--- a/internal/models/model.go
+++ b/internal/models/model.go
@@ -49,36 +49,6 @@ func New(dbUrl string, driverName, domain string) (*Model, error) {
 		}
 	}
 
-	// Create default orgs and sites #feat-119
-	if err := model.CreateDefaultTenantAndSite(); err != nil {
-		return nil, err
-	}
-
-	// Associate agents without site to default site #feat-119
-	if err := model.AssociateAgentsToDefaultTenantAndSite(); err != nil {
-		return nil, err
-	}
-
-	// Associate tags without tenant to default tenant #feat-119
-	if err := model.AssociateTagsToDefaultTenant(); err != nil {
-		return nil, err
-	}
-
-	// Associate metadata without tenant to default tenant #feat-119
-	if err := model.AssociateMetadataToDefaultTenant(); err != nil {
-		return nil, err
-	}
-
-	// Associate profiles without tenant to default tenant #feat-119
-	if err := model.AssociateProfilesToDefaultTenantAndSite(); err != nil {
-		return nil, err
-	}
-
-	// Associate domain to default site #feat-119
-	if err := model.AssociateDomainToDefaultSite(domain); err != nil {
-		return nil, err
-	}
-
 	return &model, nil
 }
 

--- a/internal/views/dashboard_views/dashboard.templ
+++ b/internal/views/dashboard_views/dashboard.templ
@@ -171,7 +171,7 @@ templ Dashboard(c echo.Context, data DashboardData, commonInfo *partials.CommonI
 							<td class="!align-middle text-center">
 								<a
 									href={ templ.URL(partials.GetNavigationUrl(commonInfo, "/security/updates?filterByAntivirusEnabled1=Disabled")) }
-									hx-get={ string(templ.URL(fmt.Sprintf(partials.GetNavigationUrl(commonInfo, "/security/updates?filterByAntivirusEnabled1=Disabled")))) }
+									hx-get={ string(templ.URL(partials.GetNavigationUrl(commonInfo, "/security/updates?filterByAntivirusEnabled1=Disabled"))) }
 									hx-target="#main"
 									hx-swap="outerHTML"
 									hx-push-url="true"


### PR DESCRIPTION
There's an issue if initial settings are not ready when console tries to create the default org and site, as the settings cannot be cloned. This affects only new installations if the database is not ready when the console starts