### PR TITLE
fix: detects wrong unix local user/group task and checked force item

### DIFF
--- a/internal/views/partials/local_user.partials.templ
+++ b/internal/views/partials/local_user.partials.templ
@@ -260,13 +260,14 @@ templ UnixLocalUserComponent(t *ent.Task) {
 						id="local-user-force"
 						name="local-user-force"
 						type="checkbox"
-						if t.Type == task.TypeAddUnixLocalUser {
+						if t.Type == task.TypeAddUnixLocalUser || t.Type == task.TypeRemoveUnixLocalUser {
 							checked?={ t.Name != "" && t.LocalUserForce }
 						}
 					/>
 					if t.Type == task.TypeAddUnixLocalUser {
 						{ i18n.T(ctx, "tasks.local_user_overwrite_ssh_key") }
-					} else {
+					}
+					if t.Type == task.TypeRemoveUnixLocalUser {
 						{ i18n.T(ctx, "tasks.local_user_remove_directories") }
 					}
 				</label>

--- a/internal/views/partials/task.select.partials.templ
+++ b/internal/views/partials/task.select.partials.templ
@@ -435,7 +435,7 @@ func IsWindowsLocalGroupTask(t *ent.Task) bool {
 }
 
 func IsUnixLocalGroupTask(t *ent.Task) bool {
-	tasks := []string{string(task.TypeAddUnixLocalGroup), string(task.TypeRemoveUnixLocalUser)}
+	tasks := []string{string(task.TypeAddUnixLocalGroup), string(task.TypeRemoveUnixLocalGroup)}
 	return t != nil && slices.Contains(tasks, t.Type.String())
 }
 


### PR DESCRIPTION
There was an issue detecting the Remove Local User task and the LocalUseForce column data wasn't displayed correctly for this task (new logic added to detect if checked property is enabled or disabled)

<img width="1078" height="686" alt="image" src="https://github.com/user-attachments/assets/7f696a3e-5a7f-4bf9-aee6-d48336588764" />

Closes #350 