### PR TITLE
feat: show domain info for Windows agents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/mssola/useragent v1.0.0
 	github.com/nats-io/nats.go v1.47.0
-	github.com/open-uem/ent v0.0.0-20251017131532-38c6f9d2010c
+	github.com/open-uem/ent v0.0.0-20251126175127-5b62eec222c4
 	github.com/open-uem/nats v0.0.0-20250930102922-09c2a23b0598
 	github.com/open-uem/utils v0.0.0-20251014101747-824dc3574744
 	github.com/open-uem/wingetcfg v0.0.0-20251011111407-80e823d91ea5

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/open-uem/ent v0.0.0-20251015114348-c80a47fa2c01 h1:Nnq63H1j1AvfPtU2Cc
 github.com/open-uem/ent v0.0.0-20251015114348-c80a47fa2c01/go.mod h1:TkCPQ+cFFwCdDflqc2/XKTZIN/ZJGJenbvUSIZOEzsk=
 github.com/open-uem/ent v0.0.0-20251017131532-38c6f9d2010c h1:YU5wSYfrQ82DYrfzHtPODXwDBuIIeBi1lJhntsyYfVU=
 github.com/open-uem/ent v0.0.0-20251017131532-38c6f9d2010c/go.mod h1:TkCPQ+cFFwCdDflqc2/XKTZIN/ZJGJenbvUSIZOEzsk=
+github.com/open-uem/ent v0.0.0-20251126175127-5b62eec222c4 h1:gS1QsDuECxcPgfld+lxt/7P+2PZNHzOKC4GfzzRJs4U=
+github.com/open-uem/ent v0.0.0-20251126175127-5b62eec222c4/go.mod h1:TkCPQ+cFFwCdDflqc2/XKTZIN/ZJGJenbvUSIZOEzsk=
 github.com/open-uem/nats v0.0.0-20250930102922-09c2a23b0598 h1:ZoQPa5pxWDPr7uCgAKZ5M5phVc2zxAgfp7UppSroxMo=
 github.com/open-uem/nats v0.0.0-20250930102922-09c2a23b0598/go.mod h1:JB6zAM56L+iD+BLn3o/vNdg9X5IFn52dSvltnIdiQAQ=
 github.com/open-uem/utils v0.0.0-20251014101747-824dc3574744 h1:ybzOjwnzh6KxUtdtu/n71kZNLB208P5keBB0Me1i2nQ=

--- a/internal/views/computers_views/operating_system.templ
+++ b/internal/views/computers_views/operating_system.templ
@@ -47,6 +47,12 @@ templ OperatingSystem(c echo.Context, p partials.PaginationAndSort, agent *ent.A
 							<th>{ i18n.T(ctx, "agents.hostname") }</th>
 							<td>{ agent.Hostname }</td>
 						</tr>
+						if agent.Os == "windows" {
+							<tr>
+								<th>{ i18n.T(ctx, "inventory.os.domain") }</th>
+								<td>{ agent.Edges.Operatingsystem.Domain }</td>
+							</tr>
+						}
 						<tr>
 							<th>{ i18n.T(ctx, "inventory.os.username") }</th>
 							<td>{ agent.Edges.Operatingsystem.Username }</td>

--- a/internal/views/locales/ca.yaml
+++ b/internal/views/locales/ca.yaml
@@ -363,6 +363,7 @@ ca:
       username: "Nom d'usuari"
       installation: "Data d'instal·lació"
       last_bootup: "Última arrencada"
+      domain: "Domini"
     monitor:
       title: "Monitors"
       description: "Aquests són els monitors connectats a aquest ordinador segons informa l'agent OpenUEM"

--- a/internal/views/locales/de.yaml
+++ b/internal/views/locales/de.yaml
@@ -363,6 +363,7 @@ de:
       username: "Benutzername"
       installation: "Installationsdatum"
       last_bootup: "Letzter Start"
+      domain: "Domain"
     monitor:
       title: "Monitore"
       description: "Dies sind die mit diesem Computer verbundenen Monitore, wie sie vom OpenUEM-Agent gemeldet wurden"

--- a/internal/views/locales/en.yaml
+++ b/internal/views/locales/en.yaml
@@ -363,6 +363,7 @@ en:
       username: "Username"
       installation: "Installation date"
       last_bootup: "Last Bootup"
+      domain: "Domain"
     monitor:
       title: "Monitors"
       description: "These are the monitors connected to this computer as reported by the OpenUEM agent"

--- a/internal/views/locales/es.yaml
+++ b/internal/views/locales/es.yaml
@@ -363,6 +363,7 @@ es:
       username: "Usuario"
       installation: "Fecha de instalación"
       last_bootup: "Último arranque"
+      domain: "Dominio"
     monitor:
       title: "Monitores"
       description: "Estos son los monitores conectados a este equipo de acuerdo con lo informado por el agente de OpenUEM"

--- a/internal/views/locales/fr.yaml
+++ b/internal/views/locales/fr.yaml
@@ -363,6 +363,7 @@ fr:
       username: "Nom d'utilisateur"
       installation: "Date d'installation"
       last_bootup: "Dernier démarrage"
+      domain: "Domaine"
     monitor:
       title: "Moniteurs"
       description: "Ce sont les moniteurs connectés à cet ordinateur, tels que signalés par l'agent OpenUEM"


### PR DESCRIPTION
Domain info is shown for Windows agents

<img width="1917" height="524" alt="image" src="https://github.com/user-attachments/assets/d526440a-786c-4059-ae7a-d979c6f3b5b5" />

Closes #353 