### PR TITLE
fix: refresh should honor paging, sorting and filtering

### DIFF
--- a/internal/views/admin_views/sites_views.templ
+++ b/internal/views/admin_views/sites_views.templ
@@ -44,7 +44,7 @@ templ Sites(c echo.Context, p partials.PaginationAndSort, f filters.SiteFilter, 
 									f.CreatedFrom == "" && f.CreatedTo == "" && f.ModifiedFrom == "" && f.ModifiedTo == "" &&
 									len(f.DefaultOptions) == 0
 							})
-							@partials.RefreshPage(commonInfo.Translator, string(templ.URL(fmt.Sprintf("/tenant/%s/admin/sites", commonInfo.TenantID))), "#main", "outerHTML", "get", refresh, true)
+							@partials.RefreshPage(c, commonInfo.Translator, refresh, true)
 						</div>
 						<div class="uk-flex uk-flex-right@s uk-width-1-1@s gap-4 my-4">
 							<button

--- a/internal/views/admin_views/tenants_views.templ
+++ b/internal/views/admin_views/tenants_views.templ
@@ -45,7 +45,7 @@ templ Tenants(c echo.Context, p partials.PaginationAndSort, f filters.TenantFilt
 									f.CreatedFrom == "" && f.CreatedTo == "" && f.ModifiedFrom == "" && f.ModifiedTo == "" &&
 									len(f.DefaultOptions) == 0
 							})
-							@partials.RefreshPage(commonInfo.Translator, "/admin/tenants", "#main", "outerHTML", "post", refresh, true)
+							@partials.RefreshPage(c, commonInfo.Translator, refresh, true)
 						</div>
 						<div class="uk-flex uk-flex-right@s uk-width-1-1@s gap-4 my-4">
 							<button

--- a/internal/views/admin_views/update_agents.templ
+++ b/internal/views/admin_views/update_agents.templ
@@ -93,7 +93,7 @@ templ UpdateAgents(c echo.Context, p partials.PaginationAndSort, f filters.Updat
 								<hr class="uk-divider-icon"/>
 								<div class="flex justify-between">
 									<div class="flex items-center gap-4">
-										@partials.RefreshPage(commonInfo.Translator, string(templ.URL(fmt.Sprintf("/tenant/%s/admin/update-agents", commonInfo.TenantID))), "#main", "outerHTML", "get", refresh, false)
+										@partials.RefreshPage(c, commonInfo.Translator, refresh, false)
 										@filters.ClearFilters(string(templ.URL(fmt.Sprintf("/tenant/%s/admin/update-agents", commonInfo.TenantID))), "#main", "outerHTML", func() bool {
 											return f.Nickname == "" && len(f.Releases) == 0 && len(f.Tags) == 0 &&
 												len(f.TaskStatus) == 0 && len(f.TaskResult) == 0 &&

--- a/internal/views/admin_views/update_servers_views.templ
+++ b/internal/views/admin_views/update_servers_views.templ
@@ -77,7 +77,7 @@ templ UpdateServers(c echo.Context, p partials.PaginationAndSort, f filters.Upda
 								<hr class="uk-divider-icon"/>
 								<div class="flex justify-between">
 									<div class="flex items-center gap-4">
-										@partials.RefreshPage(commonInfo.Translator, "/admin/update-servers", "#main", "outerHTML", "get", refresh, false)
+										@partials.RefreshPage(c, commonInfo.Translator, refresh, false)
 										@filters.ClearFilters("/admin/update-servers", "#main", "outerHTML", func() bool {
 											return f.Hostname == "" && len(f.Releases) == 0 &&
 												len(f.UpdateStatus) == 0 && f.UpdateMessage == "" &&

--- a/internal/views/admin_views/users_views.templ
+++ b/internal/views/admin_views/users_views.templ
@@ -50,7 +50,7 @@ templ Users(c echo.Context, p partials.PaginationAndSort, f filters.UserFilter, 
 									f.CreatedFrom == "" && f.CreatedTo == "" && f.ModifiedFrom == "" && f.ModifiedTo == "" &&
 									len(f.RegisterOptions) == 0
 							})
-							@partials.RefreshPage(commonInfo.Translator, "/admin/users", "#main", "outerHTML", "post", refresh, true)
+							@partials.RefreshPage(c, commonInfo.Translator, refresh, true)
 						</div>
 						<div class="uk-flex uk-flex-right@s uk-width-1-1@s gap-4 my-4">
 							<button

--- a/internal/views/agents_views/agents.templ
+++ b/internal/views/agents_views/agents.templ
@@ -151,7 +151,7 @@ templ Agents(c echo.Context, p partials.PaginationAndSort, f filters.AgentFilter
 							</button>
 						</form>
 					</div>
-					@partials.RefreshPage(commonInfo.Translator, string(templ.URL(partials.GetNavigationUrl(commonInfo, "/agents"))), "#main", "outerHTML", "post", refresh, true)
+					@partials.RefreshPage(c, commonInfo.Translator, refresh, true)
 				</div>
 				if len(agents) > 0 {
 					<table
@@ -668,7 +668,7 @@ templ AgentsLog(c echo.Context, agent *ent.Agent, agentLog, updaterLog []LogEntr
 									{ i18n.T(ctx, "Filter") }
 								</button>
 							</form>
-							@partials.RefreshPage(commonInfo.Translator, string(partials.GetNavigationUrl(commonInfo, fmt.Sprintf("/agents/%s/logs", agent.ID))), "#main", "outerHTML", "get", refresh, true)
+							@partials.RefreshPage(c, commonInfo.Translator, refresh, true)
 						</div>
 						<div class="flex flex-col gap-4">
 							<div class="flex flex-col gap-4">

--- a/internal/views/computers_views/computers_views.templ
+++ b/internal/views/computers_views/computers_views.templ
@@ -47,7 +47,7 @@ templ Computers(c echo.Context, p partials.PaginationAndSort, f filters.AgentFil
 							len(f.OSVersions) == 0 && f.Username == "" && len(f.ComputerManufacturers) == 0 &&
 							len(f.ComputerModels) == 0 && len(f.Tags) == 0 && len(f.WithApplication) == 0 && len(f.IsRemote) == 0
 					})
-					@partials.RefreshPage(commonInfo.Translator, string(templ.URL(partials.GetNavigationUrl(commonInfo, "/computers"))), "#main", "outerHTML", "post", refreshTime, true)
+					@partials.RefreshPage(c, commonInfo.Translator, refreshTime, true)
 				</div>
 				if len(agents) > 0 {
 					<form class="mt-5 mb-2">

--- a/internal/views/computers_views/deploy_views.templ
+++ b/internal/views/computers_views/deploy_views.templ
@@ -91,7 +91,7 @@ templ ComputerDeploy(c echo.Context, p partials.PaginationAndSort, agent *ent.Ag
 											{ i18n.T(ctx, "agents.no_deployments") }
 										}
 									</p>
-									@partials.RefreshPage(commonInfo.Translator, string(templ.URL(partials.GetNavigationUrl(commonInfo, fmt.Sprintf("/computers/%s/deploy", agent.ID)))), "#main", "outerHTML", "get", refreshTime, true)
+									@partials.RefreshPage(c, commonInfo.Translator, refreshTime, true)
 								</div>
 								<div>
 									if p.NItems > 0 {

--- a/internal/views/dashboard_views/dashboard.templ
+++ b/internal/views/dashboard_views/dashboard.templ
@@ -60,7 +60,7 @@ templ Dashboard(c echo.Context, data DashboardData, commonInfo *partials.CommonI
 				@Chart("Agents By OS Version", "Agent distribution by operating system version", data.Charts.AgentByOsVersion)
 			</div>
 			<div class="flex justify-end">
-				@partials.RefreshPage(commonInfo.Translator, string(templ.URL(partials.GetNavigationUrl(commonInfo, "/dashboard"))), "#main", "outerHTML", "get", data.RefreshTime, true)
+				@partials.RefreshPage(c, commonInfo.Translator, data.RefreshTime, true)
 			</div>
 			<div class="flex gap-2 justify-start">
 				<table class="uk-table uk-table-divider uk-table-small uk-table-hover uk-table-striped mt-6 w-1/3">

--- a/internal/views/partials/refresh.partials.templ
+++ b/internal/views/partials/refresh.partials.templ
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"github.com/gohugoio/locales"
 	"github.com/invopop/ctxi18n/i18n"
+	"github.com/labstack/echo/v4"
 	"time"
 )
 
-templ RefreshPage(l locales.Translator, url, target, swap, method string, refreshTime int, showTime bool) {
+templ RefreshPage(c echo.Context, l locales.Translator, refreshTime int, showTime bool) {
 	<div class="flex gap-4 items-center">
 		if showTime {
 			<span class="uk-text-small uk-text-muted">{ i18n.T(ctx, "Updated at", l.FmtTimeMedium(time.Now())) }</span>
@@ -16,13 +17,9 @@ templ RefreshPage(l locales.Translator, url, target, swap, method string, refres
 			type="button"
 			class="uk-button uk-button-default"
 			hx-push-url="false"
-			if method == "post" {
-				hx-post={ url }
-			} else {
-				hx-get={ url }
-			}
-			hx-target={ target }
-			hx-swap={ swap }
+			hx-get={ c.Request().URL.RequestURI() }
+			hx-target="#main"
+			hx-swap="outerHTML"
 			hx-trigger={ fmt.Sprintf("click, every %dm", refreshTime) }
 			_="on click add .animate-spin to #refresh-icon"
 		>

--- a/internal/views/security_views/antivirus_views.templ
+++ b/internal/views/security_views/antivirus_views.templ
@@ -39,7 +39,7 @@ templ Antivirus(c echo.Context, p partials.PaginationAndSort, f filters.Antiviru
 									len(f.AntivirusEnabledOptions) == 0 && len(f.AntivirusUpdatedOptions) == 0
 							
 							})
-							@partials.RefreshPage(commonInfo.Translator, string(templ.URL(partials.GetNavigationUrl(commonInfo, "/security"))), "#main", "outerHTML", "post", refresh, true)
+							@partials.RefreshPage(c, commonInfo.Translator, refresh, true)
 						</div>
 						if len(antiviri) > 0 {
 							<table class="uk-table uk-table-divider uk-table-small uk-table-striped ">

--- a/internal/views/security_views/updates_views.templ
+++ b/internal/views/security_views/updates_views.templ
@@ -41,7 +41,7 @@ templ SecurityUpdates(c echo.Context, p partials.PaginationAndSort, f filters.Sy
 									f.LastInstallFrom == "" && f.LastInstallTo == "" &&
 									len(f.PendingUpdateOptions) == 0
 							})
-							@partials.RefreshPage(commonInfo.Translator, string(templ.URL(partials.GetNavigationUrl(commonInfo, "/security/updates"))), "#main", "outerHTML", "post", refresh, true)
+							@partials.RefreshPage(c, commonInfo.Translator, refresh, true)
 						</div>
 						if len(systemUpdates) > 0 {
 							<table class="uk-table uk-table-divider uk-table-small uk-table-striped ">

--- a/internal/views/software_views/software_views.templ
+++ b/internal/views/software_views/software_views.templ
@@ -34,7 +34,7 @@ templ Software(c echo.Context, p partials.PaginationAndSort, f filters.Applicati
 					@filters.ClearFilters(string(templ.URL(partials.GetNavigationUrl(commonInfo, "/software"))), "#main", "outerHTML", func() bool {
 						return f.AppName == "" && f.Vendor == ""
 					})
-					@partials.RefreshPage(commonInfo.Translator, string(templ.URL(partials.GetNavigationUrl(commonInfo, "/software"))), "#main", "outerHTML", "get", refresh, true)
+					@partials.RefreshPage(c, commonInfo.Translator, refresh, true)
 				</div>
 				if len(apps) > 0 {
 					<table class="uk-table uk-table-divider uk-table-small uk-table-striped ">


### PR DESCRIPTION
RefreshPage now uses the current URI (path and query) to refresh the content using HTMX honoring the filters, paging and sorting applied

Closes #397 