### PR TITLE
fix: pass filter by source in package deployment

### DIFF
--- a/internal/controllers/webserver/handlers/deploy.go
+++ b/internal/controllers/webserver/handlers/deploy.go
@@ -179,7 +179,7 @@ func (h *Handler) SelectPackageDeployment(c echo.Context) error {
 	p.GetPaginationAndSortParams(c.FormValue("page"), c.FormValue("pageSize"), c.FormValue("sortBy"), c.FormValue("sortOrder"), c.FormValue("currentSortBy"), itemsPerPage)
 
 	p.SortBy = "nickname"
-	p.NItems, err = h.Model.CountAllAgents(filters.AgentFilter{}, true, commonInfo)
+	p.NItems, err = h.Model.CountAllAgents(f, true, commonInfo)
 	if err != nil {
 		return RenderError(c, partials.ErrorMessage(err.Error(), true))
 	}
@@ -200,7 +200,7 @@ func (h *Handler) SelectPackageDeployment(c echo.Context) error {
 		refreshTime = 5
 	}
 
-	return RenderView(c, deploy_views.DeployIndex("", deploy_views.SelectPackageDeployment(c, p, f, packageId, packageName, agents, install, refreshTime, itemsPerPage, commonInfo), commonInfo))
+	return RenderView(c, deploy_views.DeployIndex("", deploy_views.SelectPackageDeployment(c, p, f, packageId, packageName, source, agents, install, refreshTime, itemsPerPage, commonInfo), commonInfo))
 }
 
 func (h *Handler) DeployPackageToSelectedAgents(c echo.Context) error {

--- a/internal/views/deploy_views/deploy_views.templ
+++ b/internal/views/deploy_views/deploy_views.templ
@@ -181,6 +181,7 @@ templ SearchPacketResult(install bool, packages []nats.SoftwarePackage, c echo.C
 							>
 								<input type="hidden" name="filterByPackageId" value={ p.ID }/>
 								<input type="hidden" name="filterByPackageName" value={ p.Name }/>
+								<input type="hidden" name="filterBySource" value={ p.Source }/>
 								if install {
 									<input type="hidden" name="filterByInstallationType" value="true"/>
 								} else {
@@ -219,7 +220,7 @@ templ SearchPacketResult(install bool, packages []nats.SoftwarePackage, c echo.C
 	}
 }
 
-templ SelectPackageDeployment(c echo.Context, p partials.PaginationAndSort, f filters.AgentFilter, packageId, packageName string, agents []*ent.Agent, install bool, refresh int, itemsPerPage int, commonInfo *partials.CommonInfo) {
+templ SelectPackageDeployment(c echo.Context, p partials.PaginationAndSort, f filters.AgentFilter, packageId, packageName, packageSource string, agents []*ent.Agent, install bool, refresh int, itemsPerPage int, commonInfo *partials.CommonInfo) {
 	if install {
 		<title>OpenUEM | { i18n.T(ctx, "Deploy") } | { i18n.T(ctx, "Install") } </title>
 		@partials.Header(c, []partials.Breadcrumb{{Title: i18n.T(ctx, "Deploy"), Url: string(templ.URL(partials.GetNavigationUrl(commonInfo, "/deploy")))}, {Title: "Install", Url: string(templ.URL(partials.GetNavigationUrl(commonInfo, "/deploy/install")))}, {Title: packageName, Url: ""}}, commonInfo)
@@ -272,6 +273,7 @@ templ SelectPackageDeployment(c echo.Context, p partials.PaginationAndSort, f fi
 							<input type="hidden" name="filterByInstallationType" value={ strconv.FormatBool(install) }/>
 							<input type="hidden" name="filterByPackageId" value={ packageId }/>
 							<input type="hidden" name="filterByPackageName" value={ packageName }/>
+							<input type="hidden" name="filterBySource" value={ packageSource }/>
 							<input id="filterBySelectedItems" type="hidden" name="filterBySelectedItems" value={ strconv.Itoa(f.SelectedItems) }/>
 							<input id="selectedAgents" type="hidden" name="selectedAgents"/>
 							<button


### PR DESCRIPTION
Now if we select a package to be deployed for a specific OS, only agents for that OS are available to be selected 

Close #256