### PR TITLE
fix: allow RustDesk connection if no user is logged in

### DIFF
--- a/internal/views/computers_views/remote-assistance.templ
+++ b/internal/views/computers_views/remote-assistance.templ
@@ -286,14 +286,14 @@ templ RustDeskChecks(agent *ent.Agent, hasRustDeskSettings bool, commonInfo *par
 			</div>
 			<div class="flex gap-2">
 				if agent.Edges.Operatingsystem.Username == "" {
-					<uk-icon icon="x" hx-history="false" custom-class="h-5 w-5 text-red-600" uk-cloak></uk-icon>
-					{ i18n.T(ctx, "agents.remote_assistance_no_logged_user") }
+					<uk-icon hx-history="false" icon="triangle-alert" custom-class="h-5 w-5 fill-yellow-500 text-black" uk-cloack></uk-icon>
+					{ i18n.T(ctx, "agents.rustdesk_no_logged_user") }
 				} else {
 					<uk-icon icon="check" hx-history="false" custom-class="h-5 w-5 text-green-600" uk-cloak></uk-icon>
 					{ i18n.T(ctx, "agents.remote_assistance_has_logged_user", agent.Edges.Operatingsystem.Username ) }
 				}
 			</div>
-			if agent.RemoteAssistance && agent.HasRustdesk && agent.Edges.Operatingsystem.Username != "" {
+			if agent.RemoteAssistance && agent.HasRustdesk {
 				<div class="flex gap-2 items-center uk-text-small uk-text-muted uk-margin">
 					<a
 						class="flex gap-2 items-center uk-text-small"

--- a/internal/views/locales/ca.yaml
+++ b/internal/views/locales/ca.yaml
@@ -303,6 +303,7 @@ ca:
     remote_assistance_rdp_found: "L'escriptori remot de Gnome (grdctl) està instal·lat al punt final"
     remote_assistance_rdp_not_found: "L'escriptori remot del Gnome (grdctl) no està instal·lat al punt final"
     remote_assistance_no_logged_user: "No s'ha trobat cap usuari connectat al sistema"
+    rustdesk_no_logged_user: "No s'ha trobat cap usuari connectat al sistema, la connexió només és possible si s'ha establert una contrasenya permanent."
     remote_assistance_has_logged_user: "L'usuari %s ha iniciat sessió al sistema"
     remote_assistance_ip: "L'agent ha informat d'una adreça IP per connectar-se a la LAN"
     remote_assistance_no_ip: "L'agent NO ha informat d'una adreça IP per connectar-se a la LAN"

--- a/internal/views/locales/de.yaml
+++ b/internal/views/locales/de.yaml
@@ -303,6 +303,7 @@ de:
     remote_assistance_rdp_found: "Gnome Remote Desktop (grdctl) ist auf dem Endpunkt installiert"
     remote_assistance_rdp_not_found: "Gnome Remote Desktop (grdctl) ist nicht auf dem Endpunkt installiert"
     remote_assistance_no_logged_user: "Es wurde kein mit dem System verbundener Benutzer gefunden."
+    rustdesk_no_logged_user: "Es ist kein Benutzer mit dem System verbunden. Eine Verbindung ist nur möglich, wenn ein dauerhaftes Passwort festgelegt ist."
     remote_assistance_has_logged_user: "Benutzer %s ist im System angemeldet"
     remote_assistance_ip: "Der Agent hat eine IP-Adresse gemeldet, mit der eine Verbindung im LAN hergestellt werden soll"
     remote_assistance_no_ip: "Der Agent hat KEINE IP-Adresse für die Verbindung im LAN gemeldet"

--- a/internal/views/locales/en.yaml
+++ b/internal/views/locales/en.yaml
@@ -303,6 +303,7 @@ en:
     remote_assistance_rdp_found: "Gnome Remote Desktop (grdctl) is installed on the endpoint"
     remote_assistance_rdp_not_found: "Gnome Remote Desktop (grdctl) is not installed on the endpoint"
     remote_assistance_no_logged_user: "No user found connected to the system"
+    rustdesk_no_logged_user: "No user found connected to the system, connection is only possible if permanent password is set"
     remote_assistance_has_logged_user: "User %s is logged into the system"
     remote_assistance_ip: "The agent has reported an IP address to connect to in LAN"
     remote_assistance_no_ip: "The agent has NOT reported an IP address to connect to in LAN"

--- a/internal/views/locales/es.yaml
+++ b/internal/views/locales/es.yaml
@@ -303,6 +303,7 @@ es:
     remote_assistance_rdp_found: "Gnome Remote Desktop (grdctl) está instalado en el equipo"
     remote_assistance_rdp_not_found: "Gnome Remote Desktop (grdctl) no está instalado en el punto final"
     remote_assistance_no_logged_user: "No se encontró ningún usuario conectado al sistema"
+    rustdesk_no_logged_user: "No se encontró ningún usuario conectado al sistema, la conexión solo es posible si se establece una contraseña permanente"
     remote_assistance_has_logged_user: "El usuario %s ha iniciado sesión en el sistema"
     remote_assistance_ip: "El agente ha comunicado una dirección IP para conectarse en LAN"
     remote_assistance_no_ip: "El agente NO ha informado una dirección IP para conectarse en LAN"

--- a/internal/views/locales/fr.yaml
+++ b/internal/views/locales/fr.yaml
@@ -303,6 +303,7 @@ fr:
     remote_assistance_rdp_found: "Gnome Remote Desktop (grdctl) est installé sur le point de terminaison"
     remote_assistance_rdp_not_found: "Gnome Remote Desktop (grdctl) n'est pas installé sur le point de terminaison"
     remote_assistance_no_logged_user: "Aucun utilisateur connecté au système n'a été trouvé"
+    rustdesk_no_logged_user: "Aucun utilisateur connecté au système. La connexion n'est possible que si un mot de passe permanent est défini."
     remote_assistance_has_logged_user: "L'utilisateur %s est connecté au système"
     remote_assistance_ip: "L'agent a signalé une adresse IP à laquelle se connecter en LAN"
     remote_assistance_no_ip: "L'agent n'a PAS signalé d'adresse IP à laquelle se connecter en LAN"


### PR DESCRIPTION
If no user is detected as logged in, only a warn is shown before trying to establish the connection

Close #340 