### PR TITLE
fix: add encryption type to smtp settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/mssola/useragent v1.0.0
 	github.com/nats-io/nats.go v1.49.0
-	github.com/open-uem/ent v0.0.0-20260420110541-021f6acffc13
+	github.com/open-uem/ent v0.0.0-20260427091717-6f7d005adb1d
 	github.com/open-uem/nats v0.11.1-0.20260327113100-98373a46adcf
 	github.com/open-uem/openuem-ansible-config v0.0.0-20260327072817-2d801600b177
 	github.com/open-uem/utils v0.0.0-20260420170122-91c07c6c24cb

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,10 @@ github.com/open-uem/ent v0.0.0-20260417163453-1f6d3eab61fc h1:I/oiXkg3laIJTlaP3C
 github.com/open-uem/ent v0.0.0-20260417163453-1f6d3eab61fc/go.mod h1:pnv1dXKu1JK/9XRIPkLBT1Ijxvqe6jDlatIQh6un37o=
 github.com/open-uem/ent v0.0.0-20260420110541-021f6acffc13 h1:zsQgAriDY7mrKntRgQQmuzL5DUtW85FDVb7QUF5Akg4=
 github.com/open-uem/ent v0.0.0-20260420110541-021f6acffc13/go.mod h1:pnv1dXKu1JK/9XRIPkLBT1Ijxvqe6jDlatIQh6un37o=
+github.com/open-uem/ent v0.0.0-20260427091047-858fcad35426 h1:9HWXTjB7K5Vxgakijt0LeUuXDFYFbVu+8WOAIuClge8=
+github.com/open-uem/ent v0.0.0-20260427091047-858fcad35426/go.mod h1:pnv1dXKu1JK/9XRIPkLBT1Ijxvqe6jDlatIQh6un37o=
+github.com/open-uem/ent v0.0.0-20260427091717-6f7d005adb1d h1:FiwlrwWrpK1bUY13ZIBxufJoqKsETVGrX1ZfH47erpw=
+github.com/open-uem/ent v0.0.0-20260427091717-6f7d005adb1d/go.mod h1:pnv1dXKu1JK/9XRIPkLBT1Ijxvqe6jDlatIQh6un37o=
 github.com/open-uem/nats v0.11.1-0.20260327113100-98373a46adcf h1:MLhSkmuRM9sWDHJsgVnPYGv7amdF4rKoYWI7qMg40PA=
 github.com/open-uem/nats v0.11.1-0.20260327113100-98373a46adcf/go.mod h1:chcBtTU0QNmPvWecVPVlGe5LcEBHevv1Ee+ye8AnLAg=
 github.com/open-uem/openuem-ansible-config v0.0.0-20260327072817-2d801600b177 h1:E5/n5IlKxFdz/B+FWdPx5XygJ4ILXkokWTvBn1O87q0=

--- a/internal/controllers/webserver/handlers/smtp.go
+++ b/internal/controllers/webserver/handlers/smtp.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/invopop/ctxi18n/i18n"
 	"github.com/labstack/echo/v4"
+	smtpsettings "github.com/open-uem/ent/settings"
 	"github.com/open-uem/openuem-console/internal/models"
 	"github.com/open-uem/openuem-console/internal/views/admin_views"
 	"github.com/open-uem/openuem-console/internal/views/partials"
@@ -31,11 +32,18 @@ func (h *Handler) SMTPSettings(c echo.Context) error {
 			return RenderError(c, partials.ErrorMessage(err.Error(), false))
 		}
 
-		// encrypt the SMTP Password if we have the encryption master key
+		// encrypt the SMTP Password if we have the encryption master key and the password is not already encrypted
 		if h.EncryptionMasterKey != "" {
-			settings.Password, err = utils.EncryptSensitiveField(settings.Password, h.EncryptionMasterKey)
+			isSMTPPasswordEncrypted, err := utils.IsSensitiveFieldEncrypted(settings.Password, h.EncryptionMasterKey)
 			if err != nil {
-				return RenderError(c, partials.ErrorMessage(i18n.T(c.Request().Context(), "smtp.cannot_be_encrypted"), true))
+				return err
+			}
+
+			if !isSMTPPasswordEncrypted {
+				settings.Password, err = utils.EncryptSensitiveField(settings.Password, h.EncryptionMasterKey)
+				if err != nil {
+					return RenderError(c, partials.ErrorMessage(i18n.T(c.Request().Context(), "smtp.cannot_be_encrypted"), true))
+				}
 			}
 		}
 
@@ -100,6 +108,7 @@ func validateSMTPSettings(c echo.Context) (*models.SMTPSettings, error) {
 	settings.Password = c.FormValue("password")
 	settings.Auth = c.FormValue("auth")
 	settings.MailFrom = c.FormValue("mail-from")
+	settings.EncryptionType = c.FormValue("encryption")
 
 	if settingsId == "" {
 		return nil, fmt.Errorf("%s", i18n.T(c.Request().Context(), "smtp.id_cannot_be_empty"))
@@ -137,6 +146,10 @@ func validateSMTPSettings(c echo.Context) (*models.SMTPSettings, error) {
 
 	if settings.MailFrom == "" {
 		return nil, fmt.Errorf("%s", i18n.T(c.Request().Context(), "smtp.mailfrom_cannot_be_empty"))
+	}
+
+	if !slices.Contains([]string{string(smtpsettings.SMTPEncryptionTypeNone), string(smtpsettings.SMTPEncryptionTypeSmtps), string(smtpsettings.SMTPEncryptionTypeStarttls)}, settings.EncryptionType) {
+		return nil, fmt.Errorf("%s", i18n.T(c.Request().Context(), "smtp.encription_invalid"))
 	}
 
 	if errs := validate.Var(settings.MailFrom, "email"); errs != nil {
@@ -177,6 +190,14 @@ func (h *Handler) SendEmailTest(settings *models.SMTPSettings, to string) error 
 	}
 	if err != nil {
 		return err
+	}
+
+	if settings.EncryptionType == string(smtpsettings.SMTPEncryptionTypeSmtps) {
+		c.SetSSL(true)
+	}
+
+	if settings.EncryptionType == string(smtpsettings.SMTPEncryptionTypeStarttls) {
+		c.SetTLSPortPolicy(mail.TLSMandatory)
 	}
 
 	m := mail.NewMsg()

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -593,8 +593,7 @@ func (m *Model) CloneGlobalSettings(tenantID int) error {
 		SetSMTPPassword(s.SMTPPassword).
 		SetSMTPPort(s.SMTPPort).
 		SetSMTPServer(s.SMTPServer).
-		SetSMTPStarttls(s.SMTPStarttls).
-		SetSMTPTLS(s.SMTPTLS).
+		SetSMTPEncryptionType(s.SMTPEncryptionType).
 		SetSMTPUser(s.SMTPUser).
 		SetSessionLifetimeInMinutes(s.SessionLifetimeInMinutes).
 		SetUpdateChannel(s.UpdateChannel).
@@ -635,8 +634,7 @@ func (m *Model) ApplyGlobalSettings(tenantID int) error {
 		SetSMTPPassword(s.SMTPPassword).
 		SetSMTPPort(s.SMTPPort).
 		SetSMTPServer(s.SMTPServer).
-		SetSMTPStarttls(s.SMTPStarttls).
-		SetSMTPTLS(s.SMTPTLS).
+		SetSMTPEncryptionType(s.SMTPEncryptionType).
 		SetSMTPUser(s.SMTPUser).
 		SetSessionLifetimeInMinutes(s.SessionLifetimeInMinutes).
 		SetUpdateChannel(s.UpdateChannel).

--- a/internal/models/smtp.go
+++ b/internal/models/smtp.go
@@ -6,17 +6,19 @@ import (
 
 	openuem_ent "github.com/open-uem/ent"
 	"github.com/open-uem/ent/settings"
+	smtpsettings "github.com/open-uem/ent/settings"
 	"github.com/open-uem/ent/tenant"
 )
 
 type SMTPSettings struct {
-	ID       int
-	Server   string
-	Port     int
-	User     string
-	Password string
-	Auth     string
-	MailFrom string
+	ID             int
+	Server         string
+	Port           int
+	User           string
+	Password       string
+	Auth           string
+	MailFrom       string
+	EncryptionType string
 }
 
 func (m *Model) GetSMTPSettings(tenantID string) (*openuem_ent.Settings, error) {
@@ -29,9 +31,8 @@ func (m *Model) GetSMTPSettings(tenantID string) (*openuem_ent.Settings, error) 
 		settings.FieldSMTPUser,
 		settings.FieldSMTPPassword,
 		settings.FieldSMTPAuth,
-		settings.FieldSMTPTLS,
-		settings.FieldSMTPStarttls,
-		settings.FieldMessageFrom)
+		settings.FieldMessageFrom,
+		settings.FieldSMTPEncryptionType)
 
 	if tenantID == "-1" {
 		s, err = query.Where(settings.Not(settings.HasTenant())).Only(context.Background())
@@ -92,8 +93,14 @@ func (m *Model) GetSMTPSettings(tenantID string) (*openuem_ent.Settings, error) 
 }
 
 func (m *Model) UpdateSMTPSettings(settings *SMTPSettings) error {
-	mainQuery := m.Client.Settings.UpdateOneID(settings.ID).SetSMTPServer(settings.Server).SetSMTPPort(settings.Port).SetSMTPUser(settings.User).SetSMTPPassword(settings.Password).SetMessageFrom(settings.MailFrom)
-	return mainQuery.Exec(context.Background())
+	return m.Client.Settings.UpdateOneID(settings.ID).
+		SetSMTPServer(settings.Server).
+		SetSMTPPort(settings.Port).
+		SetSMTPUser(settings.User).
+		SetSMTPPassword(settings.Password).
+		SetMessageFrom(settings.MailFrom).
+		SetSMTPEncryptionType(smtpsettings.SMTPEncryptionType(settings.EncryptionType)).
+		Exec(context.Background())
 }
 
 func (m *Model) IsSMTPConfigured() bool {

--- a/internal/views/admin_views/smtpsettings_views.templ
+++ b/internal/views/admin_views/smtpsettings_views.templ
@@ -5,6 +5,7 @@ import (
 	"github.com/invopop/ctxi18n/i18n"
 	"github.com/labstack/echo/v4"
 	"github.com/open-uem/ent"
+	smtpsettings "github.com/open-uem/ent/settings"
 	"github.com/open-uem/openuem-console/internal/views/layout"
 	"github.com/open-uem/openuem-console/internal/views/partials"
 	"strconv"
@@ -44,7 +45,22 @@ templ SMTPSettings(c echo.Context, settings *ent.Settings, agentsExists, servers
 									</div>
 									<div class="uk-margin">
 										<label class="uk-form-label" for="port">{ i18n.T(ctx, "smtp.port") }</label>
-										<input id="port" name="port" type="number" class="uk-input" value={ strconv.Itoa(settings.SMTPPort) } placeholder={ i18n.T(ctx, "smtp.port_placeholder") }/>
+										<input
+											id="port"
+											name="port"
+											type="number"
+											class="uk-input"
+											value={ strconv.Itoa(settings.SMTPPort) }
+											placeholder={ i18n.T(ctx, "smtp.port_placeholder") }
+											_="on keyup 
+												if my.value is '465' then 
+													set #encryption.value to 'smtps'
+												end
+												if my.value is '587' then 
+													set #encryption.value to 'starttls'
+												end
+											end"
+										/>
 									</div>
 								</fieldset>
 								<fieldset class="uk-fieldset w-1/6">
@@ -61,8 +77,16 @@ templ SMTPSettings(c echo.Context, settings *ent.Settings, agentsExists, servers
 										<label class="uk-form-label" for="auth">{ i18n.T(ctx, "smtp.auth_type") }</label>
 										<select id="auth" name="auth" class="uk-select">
 											for _, authType := range AuthTypes {
-												<option checked?={ settings.SMTPAuth == authType }>{ authType }</option>
+												<option selected?={ settings.SMTPAuth == authType }>{ authType }</option>
 											}
+										</select>
+									</div>
+									<div class="uk-margin">
+										<label class="uk-form-label" for="encryption">{ i18n.T(ctx, "smtp.encryption_type") }</label>
+										<select id="encryption" name="encryption" class="uk-select">
+											<option selected?={ settings.SMTPEncryptionType == smtpsettings.SMTPEncryptionTypeNone } value={ smtpsettings.SMTPEncryptionTypeNone.String() }>{ i18n.T(ctx, "smtp.encryption_none") }</option>
+											<option selected?={ settings.SMTPEncryptionType == smtpsettings.SMTPEncryptionTypeSmtps } value={ smtpsettings.SMTPEncryptionTypeSmtps.String() }>{ i18n.T(ctx, "smtp.encryption_smtps") }</option>
+											<option selected?={ settings.SMTPEncryptionType == smtpsettings.SMTPEncryptionTypeStarttls } value={ smtpsettings.SMTPEncryptionTypeStarttls.String() }>{ i18n.T(ctx, "smtp.encryption_starttls") }</option>
 										</select>
 									</div>
 								</fieldset>

--- a/internal/views/locales/ca.yaml
+++ b/internal/views/locales/ca.yaml
@@ -830,6 +830,11 @@ ca:
     test: "Configuració de prova"
     test_success: "La prova de correu electrònic s'ha enviat correctament a %s!"
     cannot_be_encrypted: "No s'ha pogut xifrar la contrasenya SMTP"
+    encryption_type: "Tipus d'encriptació"
+    encryption_none: "Cap"
+    encryption_smtps: "SSL/TLS"
+    encryption_starttls: "STARTTLS"
+    encription_invalid: "El tipus d'encriptació no és vàlid"
   settings:
     title: "Configuració general"
     description: "OpenUEM té alguns paràmetres que configuren el seu comportament."

--- a/internal/views/locales/de.yaml
+++ b/internal/views/locales/de.yaml
@@ -830,6 +830,11 @@ de:
     test: "Einstellungen testen"
     test_success: "E-Mail-Test wurde erfolgreich an %s gesendet!"
     cannot_be_encrypted: "SMTP-Passwort konnte nicht verschlüsselt werden"
+    encryption_type: "Verschlüsselungstyp"
+    encryption_none: "Keine"
+    encryption_smtps: "SSL/TLS"
+    encryption_starttls: "STARTTLS"
+    encription_invalid: "Der Verschlüsselungstyp ist ungültig"
   settings:
     title: "Allgemeine Einstellungen"
     description: "OpenUEM hat einige Einstellungen, die sein Verhalten konfigurieren."

--- a/internal/views/locales/en.yaml
+++ b/internal/views/locales/en.yaml
@@ -830,6 +830,11 @@ en:
     test: "Test settings"
     test_success: "Email test was sent successfully to %s!"
     cannot_be_encrypted: "Could not encrypt the SMTP password"
+    encryption_type: "Encryption type"
+    encryption_none: "None"
+    encryption_smtps: "SSL/TLS"
+    encryption_starttls: "STARTTLS"
+    encription_invalid: "Encryption type is not valid"
   settings:
     title: "General Settings"
     description: "OpenUEM has some settings that configure its behavior."

--- a/internal/views/locales/es.yaml
+++ b/internal/views/locales/es.yaml
@@ -830,6 +830,11 @@ es:
     test: "Probar config."
     test_success: "Se envió con éxito el email de prueba a %s"
     cannot_be_encrypted: "No se pudo cifrar la contraseña SMTP"
+    encryption_type: "Tipo de encriptación"
+    encryption_none: "Ninguno"
+    encryption_smtps: "SSL/TLS"
+    encryption_starttls: "STARTTLS"
+    encription_invalid: "El tipo de encriptación no es válido"
   settings:
     title: "Configuración general"
     description: "OpenUEM tiene algunos ajustes que configuran su comportamiento."

--- a/internal/views/locales/fr.yaml
+++ b/internal/views/locales/fr.yaml
@@ -830,6 +830,11 @@ fr:
     test: "Paramètres de test"
     test_success: "Le test d'e-mail a été envoyé avec succès à %s !"
     cannot_be_encrypted: "Impossible de chiffrer le mot de passe SMTP"
+    encryption_type: "Type de chiffrement"
+    encryption_none: "Aucun"
+    encryption_smtps: "SSL/TLS"
+    encryption_starttls: "STARTTLS"
+    encription_invalid: "Le type de chiffrement n'est pas valide"
   settings:
     title: "Paramètres généraux"
     description: "OpenUEM a certains paramètres qui configurent son comportement."

--- a/internal/views/locales/no.yaml
+++ b/internal/views/locales/no.yaml
@@ -830,6 +830,11 @@ no:
     test: "Test innstillinger"
     test_success: "E-posttest ble sendt vellykket til %s!"
     cannot_be_encrypted: "Kunne ikke kryptere SMTP-passordet"
+    encryption_type: "Krypteringstype"
+    encryption_none: "Ingen"
+    encryption_smtps: "SSL/TLS"
+    encryption_starttls: "STARTTLS"
+    encription_invalid: "Krypteringstypen er ikke gyldig"
   settings:
     title: "Generelle innstillinger"
     description: "OpenUEM har noen innstillinger som konfigurerer hvordan den fungerer."

--- a/internal/views/locales/pt.yaml
+++ b/internal/views/locales/pt.yaml
@@ -830,6 +830,11 @@ pt:
     test: "Testar configurações"
     test_success: "Teste de e-mail enviado com sucesso para %s!"
     cannot_be_encrypted: "Não foi possível criptografar a senha SMTP"
+    encryption_type: "Tipo de criptografia"
+    encryption_none: "Nenhum"
+    encryption_smtps: "SSL/TLS"
+    encryption_starttls: "STARTTLS"
+    encription_invalid: "O tipo de criptografia não é válido"
   settings:
     title: "Configurações Gerais"
     description: "O OpenUEM possui algumas configurações que definem seu comportamento."


### PR DESCRIPTION
We have a way to specify the encryption type:

<img width="815" height="287" alt="image" src="https://github.com/user-attachments/assets/5171dcdb-3e2c-4632-9c65-ac2128ee0eb6" />

Close #458