### PR TITLE
fix: AllInOne was detected as not valid endpoint type

### DIFF
--- a/internal/controllers/webserver/handlers/computers.go
+++ b/internal/controllers/webserver/handlers/computers.go
@@ -62,7 +62,7 @@ func (h *Handler) Overview(c echo.Context) error {
 		}
 
 		if endpointType != "" {
-			if !slices.Contains([]string{"DesktopPC", "Laptop", "Server", "Tablet", "VM", "Other"}, endpointType) {
+			if !slices.Contains([]string{"DesktopPC", "Laptop", "Server", "Tablet", "VM", "AllInOne", "Other"}, endpointType) {
 				return RenderError(c, partials.ErrorMessage(i18n.T(c.Request().Context(), "agents.overview_endpoint_type_invalid"), true))
 			}
 			if err := h.Model.SaveEndpointType(agentId, endpointType, commonInfo); err != nil {


### PR DESCRIPTION
As reported by @croin the All In One endpoint type was not accepted

<img width="1749" height="393" alt="image" src="https://github.com/user-attachments/assets/dc095769-2f5a-48a7-a82f-d405f58f7de4" />

Close #480 