### PR TITLE
fix: check for at least one auth option enabled

### DIFF
--- a/internal/controllers/webserver/handlers/auth_settings.go
+++ b/internal/controllers/webserver/handlers/auth_settings.go
@@ -46,12 +46,8 @@ func (h *Handler) AuthenticationSettings(c echo.Context) error {
 			return RenderError(c, partials.ErrorMessage(i18n.T(c.Request().Context(), "authentication.could_not_parse_use_passwords"), true))
 		}
 
-		if !useCertificates && !useOIDC {
+		if !usePasswd && !useCertificates && !useOIDC {
 			return RenderError(c, partials.ErrorMessage(i18n.T(c.Request().Context(), "authentication.at_least_one_auth_method"), true))
-		}
-
-		if !useCertificates && allowRegister {
-			return RenderError(c, partials.ErrorMessage(i18n.T(c.Request().Context(), "authentication.use_certs_must_be_enabled"), true))
 		}
 
 		// if we explicitely don't want to use certs, override reenablecertauth option

--- a/internal/views/admin_views/auth_settings_views.templ
+++ b/internal/views/admin_views/auth_settings_views.templ
@@ -53,7 +53,7 @@ templ AuthenticationSettings(c echo.Context, settings *ent.Authentication, agent
 										</select>
 									</td>
 								</tr>
-								<tr id="allow-register-section" class={ templ.KV("hidden", !settings.UseCertificates) }>
+								<tr id="allow-register-section">
 									<td class="!align-middle">{ i18n.T(ctx, "authentication.allow_register_title") }</td>
 									<td class="!align-middle">{ i18n.T(ctx, "authentication.allow_register_description") }</td>
 									<td class="!align-middle">


### PR DESCRIPTION
As reported, if the password option was the only one enabled an error was shown mentioning that no auth method was enabled

I've also added a change that allows the register option to be shown no matter which auth option has been enabled

Thank you @MikaelKW for reporting this issue, this will be fixed for upcoming 0.13.0 release